### PR TITLE
change references from "Quantization" to "Quantification"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Brain Behavior Quantization and Synchronization (BBQS)
+# Brain Behavior Quantification and Synchronization (BBQS)
 
 Please visit our website by clicking [here](https://brain-bbqs.github.io)
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 'BBQS: Brain Behavior Quantization and Synchronization'
+title: 'BBQS: Brain Behavior Quantification and Synchronization'
 toc: false
 ---
 
@@ -7,7 +7,7 @@ toc: false
     h2, p { text-align: center; }
 </style>
 
-<img src="images/bbqs-image.gif" alt="Brain Behavior Quantization and Synchronization (BBQS)" width="400"/>
+<img src="images/bbqs-image.gif" alt="Brain Behavior Quantification and Synchronization (BBQS)" width="400"/>
 
 ## Vision
 

--- a/content/projects/dcaic.md
+++ b/content/projects/dcaic.md
@@ -6,7 +6,7 @@ sidebar:
   exclude: true
 ---
 
-<img src="/images/logo-square-256.jpg" alt="Brain Behavior Quantization and Synchronization (BBQS)" width="400"/>
+<img src="/images/logo-square-256.jpg" alt="Brain Behavior Quantification and Synchronization (BBQS)" width="400"/>
 
 #### Project Summary
 <div style="text-align: justify">

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,5 @@
 # Hugo configuration file
-title: Brain Behavior Quantization and Synchronization
+title: Brain Behavior Quantification and Synchronization
 
 # import hextra as module
 module:
@@ -43,7 +43,7 @@ menu:
 
 params:
   navbar:
-    displayTitle: Brain Behavior Quantization and Synchronization
+    displayTitle: Brain Behavior Quantification and Synchronization
     displayLogo: true
     logo:
       path: images/logo-square-256.jpg


### PR DESCRIPTION
Correcting the expansion of the "BBQS" acronym. It was mistakenly titled "Brain and Behavior Quantization and Synchronization" but should be "Brain and Behavior Quantification and Synchronization". 