### PR TITLE
Update Working Group pages

### DIFF
--- a/content/working-groups/_index.md
+++ b/content/working-groups/_index.md
@@ -9,10 +9,10 @@ weight: 30
 Working groups are essential to the success of a consortium project, as they bring together a range of experts from different organizations to focus on specific tasks. Each group works on a particular area of the project, collaborating to find solutions and share knowledge. By dividing the project into smaller, more manageable parts, working groups help ensure that work moves forward smoothly and deadlines are met. Together, their efforts contribute to the overall goals of the project, ensuring it achieves its desired outcomes.
 
 #### Current working groups for BBQS
-- WG-Analytics
-- WG-Devices
-- WG-Ethics, Legal, and Social Issues (WG-ELSI)
-- WG-Standards
+- [WG-Analytics](analytics)
+- WG-Devices _(Coming Soon)_
+- [WG-Ethics, Legal, and Social Issues (WG-ELSI)](elsi)
+- [WG-Standards](standards)
 
 #### Working Group Chairs
 - WG-Analytics: [Bouchard, Kristofer E](mailto:KEBouchard@lbl.gov), [Yi, Han G](mailto:Han.Yi@jhuapl.edu)

--- a/content/working-groups/_index.md
+++ b/content/working-groups/_index.md
@@ -8,14 +8,14 @@ weight: 30
 
 Working groups are essential to the success of a consortium project, as they bring together a range of experts from different organizations to focus on specific tasks. Each group works on a particular area of the project, collaborating to find solutions and share knowledge. By dividing the project into smaller, more manageable parts, working groups help ensure that work moves forward smoothly and deadlines are met. Together, their efforts contribute to the overall goals of the project, ensuring it achieves its desired outcomes.
 
-#### Current working groups for BBQS
+#### Active Working Groups
 - [WG-Analytics](analytics)
-- WG-Devices _(Coming Soon)_
+- [WG-Devices](devices)
 - [WG-Ethics, Legal, and Social Issues (WG-ELSI)](elsi)
 - [WG-Standards](standards)
 
 #### Working Group Chairs
-- WG-Analytics: [Bouchard, Kristofer E](mailto:KEBouchard@lbl.gov), [Yi, Han G](mailto:Han.Yi@jhuapl.edu)
+- WG-Analytics: [Kristofer Bouchard](https://biosciences.lbl.gov/profiles/kristofer-e-bouchard/), [Han Yi](https://scholar.google.com/citations?user=MdrCoqAAAAAJ&hl=en)
 - WG-Devices: TBD
-- WG-ELSI: [Cabrera, Laura](mailto:lcabrera@psu.edu)
-- WG-Standards: [Ruebel, Oliver](mailto:oruebel@lbl.gov), [Kline Struhl, Melissa](mailto:mekline@mit.edu)
+- WG-ELSI: [Laura Cabrera](https://rockethics.psu.edu/people/laura-cabrera/)
+- WG-Standards: [Oliver Ruebel](https://dav.lbl.gov/~oruebel/), [Melissa Kline Struhl](https://eccl.mit.edu/team-profiles/melissa-kline-struhl)

--- a/content/working-groups/analytics.md
+++ b/content/working-groups/analytics.md
@@ -18,7 +18,6 @@ To achieve this overarching goal of ensuring FAIR standards for data and models 
 
 #### Documentation
   * [Working Group Charter](https://docs.google.com/document/d/1WXW1P3-OZguuQq_aXYoFgNDhJrU5ZO8jfyb22STL2io/edit?usp=sharing)
-  * Working Group Guidance _(Coming Soon)_
 
 #### Resources
   * _(Coming Soon)_

--- a/content/working-groups/analytics.md
+++ b/content/working-groups/analytics.md
@@ -6,12 +6,25 @@ weight: 10
 
 #### Purpose
 
+The Working Group on Data Analytics and AI aims to establish and promote the sharing, refinement, and adoption of analytics and AI standards for novel sensors and multimodal data integration within the BBQS community. Specifically, the Working Group will strive towards achieving FAIR (Findable, Accessible, Interoperable, Reusable) sharing and reuse of AI and analytics derived results from brain-behavior data.
+
 #### Deliverables
+
+To achieve this overarching goal of ensuring FAIR standards for data and models across not only BBQS research consortium but also the broader community, the Working Group will: 
+  * evaluate and curate relevant ML/AI models and platforms, 
+  * assist with aggregating datasets, models, and other ML/AI resources from both within and outside the BBQS consortium. 
 
 #### Taskforce(s)
 
-#### Working Group Chairs
-- [Bouchard, Kristofer E](mailto:KEBouchard@lbl.gov)
-- [Yi, Han G](mailto:Han.Yi@jhuapl.edu)
+#### Documentation
+  * [Working Group Charter](https://docs.google.com/document/d/1WXW1P3-OZguuQq_aXYoFgNDhJrU5ZO8jfyb22STL2io/edit?usp=sharing)
+  * Working Group Guidance _(Coming Soon)_
+
+#### Resources
+  * _(Coming Soon)_
+
+#### Analytics Working Group Chairs
+  * [Bouchard, Kristofer E](mailto:KEBouchard@lbl.gov)
+  * [Yi, Han G](mailto:Han.Yi@jhuapl.edu)
 
 **_Mailing List_**: wg-analytics@brain-bbqs.org

--- a/content/working-groups/analytics.md
+++ b/content/working-groups/analytics.md
@@ -14,7 +14,7 @@ To achieve this overarching goal of ensuring FAIR standards for data and models 
   * evaluate and curate relevant ML/AI models and platforms, 
   * assist with aggregating datasets, models, and other ML/AI resources from both within and outside the BBQS consortium. 
 
-#### Taskforce(s)
+<!-- #### Taskforce(s) -->
 
 #### Documentation
   * [Working Group Charter](https://docs.google.com/document/d/1WXW1P3-OZguuQq_aXYoFgNDhJrU5ZO8jfyb22STL2io/edit?usp=sharing)
@@ -23,8 +23,10 @@ To achieve this overarching goal of ensuring FAIR standards for data and models 
 #### Resources
   * _(Coming Soon)_
 
-#### Analytics Working Group Chairs
-  * [Bouchard, Kristofer E](mailto:KEBouchard@lbl.gov)
-  * [Yi, Han G](mailto:Han.Yi@jhuapl.edu)
+#### Chairs
+- [Kristofer Bouchard](https://biosciences.lbl.gov/profiles/kristofer-e-bouchard/)
+- [Han Yi](https://scholar.google.com/citations?user=MdrCoqAAAAAJ&hl=en)
 
-**_Mailing List_**: wg-analytics@brain-bbqs.org
+#### Connect with the group
+&nbsp;&nbsp;&nbsp;&nbsp;**Chairs**: wg-chairs@brain-bbqs.org\
+&nbsp;&nbsp;&nbsp;&nbsp;**Mailing List**: wg-analytics@brain-bbqs.org

--- a/content/working-groups/devices.md
+++ b/content/working-groups/devices.md
@@ -2,13 +2,21 @@
 title: WG-Devices
 type: docs
 weight: 20
+draft: true
 ---
 
 #### Purpose
 
 #### Deliverables
 
-#### Taskforce(s)
+<!-- #### Taskforce(s) -->
+
+#### Documentation
+- Working Group Charter _(Coming Soon)_
+- Working Group Guidance _(Coming Soon)_
+
+#### Resources
+_(Coming Soon)_
 
 #### Working Group Chairs
 - TBD

--- a/content/working-groups/devices.md
+++ b/content/working-groups/devices.md
@@ -6,6 +6,7 @@ draft: true
 ---
 
 We are looking for leads for this working group. If you are interested, please [email the admin team](mailto:bbqs-admin@brain-bbqs.org).
+
 #### Purpose
 
 #### Deliverables

--- a/content/working-groups/devices.md
+++ b/content/working-groups/devices.md
@@ -2,16 +2,19 @@
 title: WG-Devices
 type: docs
 weight: 20
-draft: true
 ---
 
 We are looking for leads for this working group. If you are interested, please [email the admin team](mailto:bbqs-admin@brain-bbqs.org).
 
-#### Purpose
+<!-- #### Purpose
+
+_(Coming Soon)_
 
 #### Deliverables
 
-<!-- #### Taskforce(s) -->
+_(Coming Soon)_
+
+#### Taskforce(s)
 
 #### Documentation
 - Working Group Charter _(Coming Soon)_
@@ -21,6 +24,6 @@ We are looking for leads for this working group. If you are interested, please [
 _(Coming Soon)_
 
 #### Working Group Chairs
-- TBD
+- TBD -->
 
 **_Mailing List_**: wg-devices@brain-bbqs.org

--- a/content/working-groups/devices.md
+++ b/content/working-groups/devices.md
@@ -5,6 +5,7 @@ weight: 20
 draft: true
 ---
 
+We are looking for leads for this working group. If you are interested, please [email the admin team](mailto:bbqs-admin@brain-bbqs.org).
 #### Purpose
 
 #### Deliverables

--- a/content/working-groups/elsi.md
+++ b/content/working-groups/elsi.md
@@ -17,7 +17,6 @@ To achieve this overarching goal, the Working Group will meet with the ELSI Scie
 
 #### Documentation
 - [Working Group Charter](https://docs.google.com/document/d/1GnGAAeUUrkO5dvk_P3zXjjF0HiiIBGyy/edit?usp=sharing&ouid=117099683135763927535&rtpof=true&sd=true)
-- Working Group Guidance _(Coming Soon)_
 
 #### Resources
 _(Coming Soon)_

--- a/content/working-groups/elsi.md
+++ b/content/working-groups/elsi.md
@@ -22,7 +22,9 @@ To achieve this overarching goal, the Working Group will meet with the ELSI Scie
 #### Resources
 _(Coming Soon)_
 
-#### ELSI Working Group Chair
-- [Cabrera, Laura](mailto:lcabrera@psu.edu)
+#### Chair
+- [Laura Cabrera](https://rockethics.psu.edu/people/laura-cabrera/)
 
-**_Mailing List_**: wg-elsi@brain-bbqs.org
+#### Connect with the group
+&nbsp;&nbsp;&nbsp;&nbsp;**Chairs**: wg-chairs@brain-bbqs.org\
+&nbsp;&nbsp;&nbsp;&nbsp;**Mailing List**: wg-elsi@brain-bbqs.org

--- a/content/working-groups/elsi.md
+++ b/content/working-groups/elsi.md
@@ -6,11 +6,23 @@ weight: 30
 
 #### Purpose
 
+The Working Group on Ethical, Legal, and Societal Implications (ELSI) aims to identify and address ELSI issues that emerge from the work in the consortium projects, as well as to help establish and promote the adoption of the data sharing governance framework for the BBQS community. This effort is essential to facilitate FAIR (Findable, Accessible, Interoperable, Reusable) sharing and reuse of brain behavior data and metadata, ensuring consistency, interoperability, and integration of data and metadata to support scientific research and collaboration in an ethical and responsible manner.
+
+
 #### Deliverables
 
-#### Taskforce(s)
+To achieve this overarching goal, the Working Group will meet with the ELSI Scientific Advisory Board to identify areas to prioritize, conduct workshops on key ELSI topics to discuss with the larger BBQS community, conduct research on ethical issues to identify and create recommendations for the consortium and the broader community, and share these resources with BBQS consortium members. 
 
-#### ELSE Working Group Chair(s)
+<!-- #### Taskforce(s) -->
+
+#### Documentation
+- [Working Group Charter](https://docs.google.com/document/d/1GnGAAeUUrkO5dvk_P3zXjjF0HiiIBGyy/edit?usp=sharing&ouid=117099683135763927535&rtpof=true&sd=true)
+- Working Group Guidance _(Coming Soon)_
+
+#### Resources
+_(Coming Soon)_
+
+#### ELSI Working Group Chair
 - [Cabrera, Laura](mailto:lcabrera@psu.edu)
 
 **_Mailing List_**: wg-elsi@brain-bbqs.org

--- a/content/working-groups/standards.md
+++ b/content/working-groups/standards.md
@@ -6,11 +6,41 @@ weight: 40
 
 #### Purpose
 
+The Working Group on Data Standards aims to establish and promote the adoption of data standards for novel sensors and multimodal data integration within the BBQS community. This effort is essential to facilitate FAIR (Findable, Accessible, Interoperable, Reusable) sharing and reuse of brain behavior data, ensuring consistency, interoperability, and integration of data and metadata to support scientific research and collaboration.
+
 #### Deliverables
 
-#### Taskforce(s)
+**1. Inventory Behavior Data Standards**
+to enable the BBQS community to effectively leverage and use existing standards, ontologies, methods and tools:
+- **Goal**: Identify and review existing data standards relevant to BBQS studies. Summarize and evaluate BBQS relevant data standards to understand their applicability and gaps. 
+- **Deliverable**: Publish an organized and categorized catalog of standards for BBQS studies accessible via the BBQS web portal.
+- **Stretch goal**: Engage with the relevant data standards to promote enhancements to address relevant gaps. 
 
-#### Standards Working Group Chair(s)
+**2. Develop Guidelines and Best Practices**
+to help BBQS users understand which standards are relevant to their research and how to best use them, by:
+- Identifying where 'fault lines' lie between standards to clarify which standards are most appropriate for what types of data and developing recommendations to clarify which standard(s) are best suited for BBQS.
+- Formulating use-case driven minimum information (MI) requirement guidelines for BBQS data.
+
+**3. Coordinate and Promote Enhancement of Standards**
+to promote improvement of existing data standards to better meet BBQS needs by:
+- Facilitating the organization of community working groups to develop strategies and enhancements to standards.
+- Collaborating with standards bodies to update standards for BBQS and ensure compliance with neuroethics principles.
+- Creating crosswalks to identify common metadata fields across standards and link them to existing ontologies.
+
+**4. Facilitate Adoption and Use of BBQS Standards**
+by working with BBQS and data standards bodies and teams to: 
+- Create online tutorials and best practices to train BBQS teams in applying guidelines and best practices.
+- Develop curated controlled term sets for BBQS, leveraging existing ontologies and resources.
+- Develop mechanisms for annotating existing data standards to ease the adoption of BBQS data guidelines.
+
+#### Documentation
+- [Working Group Charter](https://docs.google.com/document/d/1WIVI8HZF4-IfZZ61UjCZx2K7NyYx_CaTuIHmhFo7eYw/edit?usp=sharing)
+- Standards Guidelines _(Coming Soon)_
+
+#### Resources
+_(Coming Soon)_
+
+#### Standards Working Group Chairs
 - [Ruebel, Oliver](mailto:oruebel@lbl.gov)
 - [Kline Struhl, Melissa](mailto:mekline@mit.edu)
 

--- a/content/working-groups/standards.md
+++ b/content/working-groups/standards.md
@@ -40,8 +40,10 @@ by working with BBQS and data standards bodies and teams to:
 #### Resources
 _(Coming Soon)_
 
-#### Standards Working Group Chairs
-- [Ruebel, Oliver](mailto:oruebel@lbl.gov)
-- [Kline Struhl, Melissa](mailto:mekline@mit.edu)
+#### Chairs
+- [Oliver Ruebel](https://dav.lbl.gov/~oruebel/)
+- [Melissa Kline Struhl](https://eccl.mit.edu/team-profiles/melissa-kline-struhl)
 
-**_Mailing List_**: wg-standards@brain-bbqs.org
+#### Connect with the group
+&nbsp;&nbsp;&nbsp;&nbsp;**Chairs**: wg-chairs@brain-bbqs.org\
+&nbsp;&nbsp;&nbsp;&nbsp;**Mailing List**: wg-standards@brain-bbqs.org


### PR DESCRIPTION
Changes
- Updated purpose and deliverables section from wg charters
- removed taskforce section for now
- added working group charters
- added 'Resources' section
- WG-Devices page hidden for now

Notes
- Resources section will be populated from resources page in another pr