### PR TITLE
Add wg standard poster

### DIFF
--- a/assets/resources.json
+++ b/assets/resources.json
@@ -379,6 +379,42 @@
       "categories": ["data-sharing", "paper"],
       "animals": [],
       "tags": ["data sharing", "FAIR", "WG-ELSI", "WG-Standards"]
+    },
+    {
+      "id": "ecosystem-standards-neuroscience-poster-2025",
+      "name": "The Ecosystem of Standards in Neuroscience: Which Ones Are For You? (SfN 2025 Poster)",
+      "url": "https://zenodo.org/records/18333008",
+      "doi": "https://doi.org/10.5281/zenodo.18333008",
+      "description": "This poster, presented at SfN 2025, provides an overview of the current ecosystem of neuroscience data standards, their interrelationships, and practical implementation guidance. It surveys established data standards for storing, transmitting, and annotating neuroscience data, and offers decision-making guidance for researchers. Case studies demonstrate successful implementation of standards to enhance research workflows and data sharing.",
+      "type": "paper",
+      "animals": [],
+      "categories": ["data-sharing", "paper"],
+      "tags": ["neuroscience", "data standards", "FAIR data", "neurophysiology", "neuroimaging", "BIDS", "NWB", "data sharing", "research data management", "BBQS", "BRAIN Initiative", "SfN", "poster", "WG-Standards"],
+        "authors": [
+          "Oliver Rübel", "Cody C. Baker", "Jyl Boline", "Kristofer Bouchard", "Andrew P. Davison", "Saskia de Vries", "Benjamin Dichter", "Andrey Fedorov", "Satrajit S. Ghosh", "Tom Gillespie", "Jeffrey S. Grethe", "Nicole Guittari", "Kabilar Gunalan", "Sean N. Hatton", "Erik Johnson", "David Keator", "David N. Kennedy", "Ryan Ly", "Christopher J. Markiewicz", "Peyman Najafi", "Steven Nichols", "Franco Pestilli", "JB Poline", "Stephanie Prince", "Kay A. Robbins", "Christopher Rorden", "Melissa Kline Struhl", "Nicole E. S. Tregoning", "Adam L. Tyson", "Thomas Wachtler", "Brock Wester", "Han Yi", "Lyuba Zehl", "Kailin Zhuang", "Yaroslav O. Halchenko"
+        ],
+      "files": [
+        {
+          "name": "SfN-2025_Poster-DataStandards.pdf",
+          "url": "https://zenodo.org/api/records/18333008/files/SfN-2025_Poster-DataStandards.pdf/content"
+        },
+        {
+          "name": "SfN-2025_Poster-DataStandards.jpg",
+          "url": "https://zenodo.org/api/records/18333008/files/SfN-2025_Poster-DataStandards.jpg/content"
+        }
+      ],
+      "event": {
+        "name": "Society for Neuroscience (SfN) annual meeting, Neuroscience 2025",
+        "acronym": "SfN",
+        "dates": "15-19 November, 2025",
+        "place": "San Diego",
+        "session": "J.07. Data Analysis and Statistics",
+        "session_part": "PSTR477.19/VV15",
+        "url": "https://www.sfn.org/meetings/neuroscience-2025"
+      },
+      "license": "CC-BY-4.0",
+      "publisher": "Zenodo",
+      "publication_date": "2025-11-11"
     }
   ],
   "categories": [

--- a/content/announcements/_index.md
+++ b/content/announcements/_index.md
@@ -7,7 +7,7 @@ weight: 40
 New hires, publications, awards, conferences, etc.
 
 _November 2025_ <br>
-- **SFN Annual Meeting 2025** - BBQS will be presenting at the Society for Neuroscience Annual Meeting in Chicago. Join us at [Booth #XXX] or attend our symposium on [Date/Time]. [More details](link-to-details)
+- **SFN Annual Meeting 2025** - BBQS will be presenting at the Society for Neuroscience Annual Meeting in Chicago. Join us at Booth #3830 (EMBER/BossDB) and #3831 (DANDI/NWB) and visit our talks, posters, and symposia. [More details](/events/#join-bbqs-at-sfn-2025)
 
 _July 2025_ <br>
 - A 3-day Consortia-Wide Workshop will be held at MIT from July 15-17, 2024. Consortia members, please check your messages for signup information and further details.

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -3,7 +3,8 @@ title: 'SFN 2025: BBQS at Neuroscience'
 weight: 1
 ---
 
-# Join BBQS at SFN 2025! 
+<span id="join-bbqs-at-sfn-2025"></span>
+# Join BBQS at SFN 2025!
 
 ### Society for Neuroscience Annual Meeting
 **November 15-19, 2025 • San Diego Convention Center, San Diego, CA**
@@ -172,6 +173,7 @@ Explore the **Distributed Archives for Neurophysiology Data Integration** (DANDI
 - **Presenters:** Oliver Ruebel, Brock Wester
 - **Keywords:** Data, Standards, Ecosystem, Community
 - **Grants:** U24 BARD.CC, R24 EMBER
+- **DOI:** [10.5281/zenodo.18333007](https://doi.org/10.5281/zenodo.18333008)
 
 **Multimodal analysis of intracranial neural data from DBS patients with psychiatric disorders**
 

--- a/content/working-groups/standards.md
+++ b/content/working-groups/standards.md
@@ -37,8 +37,9 @@ by working with BBQS and data standards bodies and teams to:
 - [Working Group Charter](https://docs.google.com/document/d/1WIVI8HZF4-IfZZ61UjCZx2K7NyYx_CaTuIHmhFo7eYw/edit?usp=sharing)
 
 #### Resources
-- [View Standards Resources](/resources?search=WG-Standards)
 - [Standards Guidelines](https://docs.google.com/document/d/1vIJ01La9G76FfGywS3IbG4o1GR4qquS31MoJ2B4_4os/edit?usp=sharing)
+- [View Standards Resources](/resources?search=WG-Standards)
+- [The Ecosystem of Standards in Neuroscience: Which Ones Are For You? (SfN 2025 Poster)](https://zenodo.org/records/18333008)
 
 #### Chairs
 - [Oliver Ruebel](https://crd.lbl.gov/divisions/scidata/computational-biosciences/members/staff/oliver-ruebel-bio/)


### PR DESCRIPTION
We released the SfN 2025 poster on the *"The Ecosystem of Standards in Neuroscience: Which Ones Are For You?"*  on Zenodo. This adds the poster to:

- [X] Added the poster to the`resources.json`
- [X] Added the poster to the WG Standards page
- [X] Added DOI to the entry for the poster on the SfN 2025 page
- [X] Fixed broken link in announcement for SfN 2025